### PR TITLE
Pass ExtendedMetadata to to `SessionMetadataCallback`.

### DIFF
--- a/pkg/sip/custom_server.go
+++ b/pkg/sip/custom_server.go
@@ -3935,6 +3935,15 @@ func buildStreamMetadata(streamLabel string, rsMeta *siprec.RSMetadata, session 
 		"stream_label": streamLabel,
 	}
 
+	if session != nil {
+		if session.ID != "" {
+			meta["session_id"] = session.ID
+		}
+		for k, v := range session.ExtendedMetadata {
+			meta[k] = v
+		}
+	}
+
 	if rsMeta == nil {
 		return meta
 	}


### PR DESCRIPTION
buildStreamMetadata now forwards session.ExtendedMetadata wholesale into the callback map. The library already stores all SIP headers there (sip_uui, sip_ucid, sip_avaya_ucid, sip_vendor_type, etc.), so any downstream consumer gets the full metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced session metadata propagation in stream processing to improve session context tracking and data correlation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->